### PR TITLE
Add <algorithm> header to Blob.cpp and Select.cpp test files

### DIFF
--- a/tests/core/usage/Select.cpp
+++ b/tests/core/usage/Select.cpp
@@ -24,6 +24,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+
 #include <sqlpp23/tests/core/all.h>
 
 struct to_cerr {

--- a/tests/postgresql/usage/Blob.cpp
+++ b/tests/postgresql/usage/Blob.cpp
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <functional>
 #include <random>
 

--- a/tests/sqlite3/usage/Blob.cpp
+++ b/tests/sqlite3/usage/Blob.cpp
@@ -24,6 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
 #include <functional>
 #include <random>
 


### PR DESCRIPTION
Include the <algorithm> header in Blob.cpp and Select.cpp test files to enable the use of standard algorithms.